### PR TITLE
min to max

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,8 @@ DEBUG := $(ALL_DEBUG)
 CURVER ?= 2.7.3
 #export DEBUG
 #export EXTRALINK
-export MAKE
+### Don't export MAKE when building packages - let containers use their own make
+# export MAKE
 export CURVER
 
 ### detect compiler support for c++11/17
@@ -78,9 +79,14 @@ ifeq ($(wildcard /usr/lib/systemd/system), /usr/lib/systemd/system)
 	SYSTEMD := 1
 endif
 
-### check user/group
-USERCHECK := $(shell getent passwd proxysql)
-GROUPCHECK := $(shell getent group proxysql)
+### check user/group (macOS compatible)
+ifeq ($(OS),Darwin)
+	USERCHECK := $(shell dscl . -read /Users/proxysql 2>/dev/null)
+	GROUPCHECK := $(shell dscl . -read /Groups/proxysql 2>/dev/null)
+else
+	USERCHECK := $(shell getent passwd proxysql 2>/dev/null)
+	GROUPCHECK := $(shell getent group proxysql 2>/dev/null)
+endif
 
 
 ### main targets
@@ -292,7 +298,11 @@ SYS_ARCH := $(shell uname -m)
 REL_ARCH := $(subst x86_64,amd64,$(subst aarch64,arm64,$(SYS_ARCH)))
 RPM_ARCH := .$(SYS_ARCH)
 DEB_ARCH := _$(REL_ARCH)
-REL_VERS := $(shell echo ${GIT_VERSION} | grep -Po '(?<=^v|^)[\d\.]+')
+ifeq ($(OS),Darwin)
+	REL_VERS := $(shell echo ${GIT_VERSION} | sed -E 's/^v?([0-9.]+).*/\1/')
+else
+	REL_VERS := $(shell echo ${GIT_VERSION} | grep -Po '(?<=^v|^)[\d\.]+')
+endif
 RPM_VERS := -$(REL_VERS)-1
 DEB_VERS := _$(REL_VERS)
 
@@ -313,7 +323,11 @@ amd64-fedora: fedora38 fedora38-clang fedora38-dbg fedora39 fedora39-clang fedor
 amd64-opensuse: opensuse15 opensuse15-clang opensuse15-dbg
 amd64-ubuntu: ubuntu16 ubuntu16-dbg ubuntu18 ubuntu18-dbg ubuntu20 ubuntu20-clang ubuntu20-dbg ubuntu22 ubuntu22-clang ubuntu22-dbg ubuntu24 ubuntu24-clang ubuntu24-dbg
 amd64-pkglist:
+ifeq ($(OS),Darwin)
+	@make -nk amd64-packages 2>/dev/null | sed -n 's/.*binaries\/\(proxysql[^ ]*\).*/\1/p'
+else
 	@make -nk amd64-packages 2>/dev/null | grep -Po '(?<=binaries/)proxysql\S+$$'
+endif
 
 arm64-packages: arm64-centos arm64-debian arm64-ubuntu arm64-fedora arm64-opensuse arm64-almalinux
 arm64-almalinux: almalinux8 almalinux9
@@ -323,7 +337,11 @@ arm64-fedora: fedora38 fedora39 fedora40 fedora41
 arm64-opensuse: opensuse15
 arm64-ubuntu: ubuntu16 ubuntu18 ubuntu20 ubuntu22 ubuntu24
 arm64-pkglist:
+ifeq ($(OS),Darwin)
+	@make -nk arm64-packages 2>/dev/null | sed -n 's/.*binaries\/\(proxysql[^ ]*\).*/\1/p'
+else
 	@make -nk arm64-packages 2>/dev/null | grep -Po '(?<=binaries/)proxysql\S+$$'
+endif
 
 almalinux%: build-almalinux% ;
 centos%: build-centos% ;
@@ -336,12 +354,21 @@ ubuntu%: build-ubuntu% ;
 .PHONY: build-%
 .NOTPARALLEL: build-%
 build-%: BLD_NAME=$(patsubst build-%,%,$@)
+ifeq ($(OS),Darwin)
+build-%: PKG_VERS=$(if $(filter $(shell echo ${BLD_NAME} | sed -n 's/.*\([a-z][a-z]*\).*/\1/p'),debian ubuntu),$(DEB_VERS),$(RPM_VERS))
+build-%: PKG_TYPE=$(if $(filter $(shell echo $(BLD_NAME) | sed -n 's/.*\(-de\?bu\?g\).*/\1/p'),-dbg -debug),-dbg,)
+build-%: PKG_NAME=$(firstword $(subst -, ,$(BLD_NAME)))
+build-%: PKG_COMP=$(if $(filter $(shell echo $(BLD_NAME) | sed -n 's/.*\(-clang\).*/\1/p'),-clang),-clang,)
+build-%: PKG_ARCH=$(if $(filter $(shell echo ${BLD_NAME} | sed -n 's/.*\([a-z][a-z]*\).*/\1/p'),debian ubuntu),$(DEB_ARCH),$(RPM_ARCH))
+build-%: PKG_KIND=$(if $(filter $(shell echo ${BLD_NAME} | sed -n 's/.*\([a-z][a-z]*\).*/\1/p'),debian ubuntu),deb,rpm)
+else
 build-%: PKG_VERS=$(if $(filter $(shell echo ${BLD_NAME} | grep -Po '[a-z]+'),debian ubuntu),$(DEB_VERS),$(RPM_VERS))
 build-%: PKG_TYPE=$(if $(filter $(shell echo $(BLD_NAME) | grep -Po '\-de?bu?g'),-dbg -debug),-dbg,)
 build-%: PKG_NAME=$(firstword $(subst -, ,$(BLD_NAME)))
 build-%: PKG_COMP=$(if $(filter $(shell echo $(BLD_NAME) | grep -Po '\-clang'),-clang),-clang,)
 build-%: PKG_ARCH=$(if $(filter $(shell echo ${BLD_NAME} | grep -Po '[a-z]+'),debian ubuntu),$(DEB_ARCH),$(RPM_ARCH))
 build-%: PKG_KIND=$(if $(filter $(shell echo ${BLD_NAME} | grep -Po '[a-z]+'),debian ubuntu),deb,rpm)
+endif
 build-%: PKG_FILE=binaries/proxysql$(PKG_VERS)$(PKG_TYPE)-$(PKG_NAME)$(PKG_COMP)$(PKG_ARCH).$(PKG_KIND)
 build-%:
 	@echo 'building $@'
@@ -354,7 +381,11 @@ binaries/proxysql%:
 	cd src && ${MAKE} clean
 	cd test/tap && ${MAKE} clean
 	cd test/deps && ${MAKE} cleanall
-	find . -not -path "./binaries/*" -not -path "./.git/*" -exec touch -h --date=@`git show -s --format=%ct HEAD` {} \;
+	if [ "$(OS)" = "Darwin" ]; then \
+		find . -not -path "./binaries/*" -not -path "./.git/*" -exec touch -h -t `date -r \`git show -s --format=%ct HEAD\` +%Y%m%d%H%M.%S` {} \; ; \
+	else \
+		find . -not -path "./binaries/*" -not -path "./.git/*" -exec touch -h --date=@`git show -s --format=%ct HEAD` {} \; ; \
+	fi
 	@docker compose -p proxysql down -v --remove-orphans
 	@docker compose -p proxysql up $(IMG_NAME)$(IMG_TYPE)$(IMG_COMP)_build
 	@docker compose -p proxysql down -v --remove-orphans

--- a/docker/images/proxysql/deb-compliant/entrypoint/entrypoint.bash
+++ b/docker/images/proxysql/deb-compliant/entrypoint/entrypoint.bash
@@ -36,6 +36,9 @@ else
 	deps_target="build_deps_$PROXYSQL_BUILD_TYPE"
 	build_target="$PROXYSQL_BUILD_TYPE"
 fi
+# Use 'make' if MAKE variable is not set
+MAKE=${MAKE:-make}
+
 #${MAKE} cleanbuild
 ${MAKE} ${MAKEOPT} "${deps_target}"
 

--- a/docker/images/proxysql/rhel-compliant/entrypoint/entrypoint.bash
+++ b/docker/images/proxysql/rhel-compliant/entrypoint/entrypoint.bash
@@ -36,6 +36,9 @@ else
 	deps_target="build_deps_$PROXYSQL_BUILD_TYPE"
 	build_target="$PROXYSQL_BUILD_TYPE"
 fi
+# Use 'make' if MAKE variable is not set
+MAKE=${MAKE:-make}
+
 #${MAKE} cleanbuild
 ${MAKE} ${MAKEOPT} "${deps_target}"
 

--- a/docker/images/proxysql/rhel-compliant/rhel6/entrypoint/entrypoint.bash
+++ b/docker/images/proxysql/rhel-compliant/rhel6/entrypoint/entrypoint.bash
@@ -36,6 +36,9 @@ else
 	deps_target="build_deps_$PROXYSQL_BUILD_TYPE"
 	build_target="$PROXYSQL_BUILD_TYPE"
 fi
+# Use 'make' if MAKE variable is not set
+MAKE=${MAKE:-make}
+
 #${MAKE} cleanbuild
 ${MAKE} ${MAKEOPT} "${deps_target}"
 

--- a/docker/images/proxysql/suse-compliant/entrypoint/entrypoint.bash
+++ b/docker/images/proxysql/suse-compliant/entrypoint/entrypoint.bash
@@ -36,6 +36,9 @@ else
 	deps_target="build_deps_$PROXYSQL_BUILD_TYPE"
 	build_target="$PROXYSQL_BUILD_TYPE"
 fi
+# Use 'make' if MAKE variable is not set
+MAKE=${MAKE:-make}
+
 #${MAKE} cleanbuild
 ${MAKE} ${MAKEOPT} "${deps_target}"
 

--- a/include/MySQL_HostGroups_Manager.h
+++ b/include/MySQL_HostGroups_Manager.h
@@ -532,6 +532,16 @@ struct p_hg_dyn_gauge {
 		connection_pool_conn_used,
 		connection_pool_latency_us,
 		connection_pool_status,
+		// PMM-Compatibility metrics
+		///////////////////////////////////////////////////////////////////////
+		runtime_servers_status,
+		runtime_servers_weight,
+		runtime_servers_compression,
+		runtime_servers_max_connections,
+		runtime_servers_max_replication_lag,
+		runtime_servers_use_ssl,
+		runtime_servers_max_latency_ms,
+		///////////////////////////////////////////////////////////////////////
 		__size
 	};
 };
@@ -914,6 +924,16 @@ class MySQL_HostGroups_Manager {
 		std::map<std::string, prometheus::Gauge*> p_connection_pool_latency_us_map {};
 		std::map<std::string, prometheus::Counter*> p_connection_pool_queries_map {};
 		std::map<std::string, prometheus::Gauge*> p_connection_pool_status_map {};
+		// PMM-Compatibility metrics
+		///////////////////////////////////////////////////////////////////////
+		std::map<std::string, prometheus::Gauge*> p_runtime_servers_status_map {};
+		std::map<std::string, prometheus::Gauge*> p_runtime_servers_weigth_map {};
+		std::map<std::string, prometheus::Gauge*> p_runtime_servers_compress_map {};
+		std::map<std::string, prometheus::Gauge*> p_runtime_servers_max_conns_map {};
+		std::map<std::string, prometheus::Gauge*> p_runtime_servers_max_repl_lag_map {};
+		std::map<std::string, prometheus::Gauge*> p_runtime_servers_use_ssl_map {};
+		std::map<std::string, prometheus::Gauge*> p_runtime_servers_max_lat_map {};
+		///////////////////////////////////////////////////////////////////////
 
 		/// Prometheus gtid_executed metrics
 		std::map<std::string, prometheus::Counter*> p_gtid_executed_map {};

--- a/include/MySQL_HostGroups_Manager.h
+++ b/include/MySQL_HostGroups_Manager.h
@@ -927,7 +927,7 @@ class MySQL_HostGroups_Manager {
 		// PMM-Compatibility metrics
 		///////////////////////////////////////////////////////////////////////
 		std::map<std::string, prometheus::Gauge*> p_runtime_servers_status_map {};
-		std::map<std::string, prometheus::Gauge*> p_runtime_servers_weigth_map {};
+		std::map<std::string, prometheus::Gauge*> p_runtime_servers_weight_map {};
 		std::map<std::string, prometheus::Gauge*> p_runtime_servers_compress_map {};
 		std::map<std::string, prometheus::Gauge*> p_runtime_servers_max_conns_map {};
 		std::map<std::string, prometheus::Gauge*> p_runtime_servers_max_repl_lag_map {};

--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -3470,7 +3470,7 @@ void MySQL_HostGroups_Manager::p_update_connection_pool() {
 			p_update_connection_pool_update_gauge(
 				endpoint_id,
 				srvs_common_labels,
-				status.p_runtime_servers_weigth_map,
+				status.p_runtime_servers_weight_map,
 				mysrvc->weight,
 				p_hg_dyn_gauge::runtime_servers_weight
 			);
@@ -3544,6 +3544,37 @@ void MySQL_HostGroups_Manager::p_update_connection_pool() {
 		gauge = status.p_connection_pool_latency_us_map[key];
 		status.p_dyn_gauge_array[p_hg_dyn_gauge::connection_pool_latency_us]->Remove(gauge);
 		status.p_connection_pool_latency_us_map.erase(key);
+
+		// PMM-Compatibility metrics
+		////////////////////////////////////////////////////////////////////
+		gauge = status.p_runtime_servers_status_map[key];
+		status.p_dyn_gauge_array[p_hg_dyn_gauge::runtime_servers_status]->Remove(gauge);
+		status.p_runtime_servers_status_map.erase(key);
+
+		gauge = status.p_runtime_servers_weight_map[key];
+		status.p_dyn_gauge_array[p_hg_dyn_gauge::runtime_servers_weight]->Remove(gauge);
+		status.p_runtime_servers_weight_map.erase(key);
+
+		gauge = status.p_runtime_servers_compress_map[key];
+		status.p_dyn_gauge_array[p_hg_dyn_gauge::runtime_servers_compression]->Remove(gauge);
+		status.p_runtime_servers_compress_map.erase(key);
+
+		gauge = status.p_runtime_servers_max_conns_map[key];
+		status.p_dyn_gauge_array[p_hg_dyn_gauge::runtime_servers_max_connections]->Remove(gauge);
+		status.p_runtime_servers_max_conns_map.erase(key);
+
+		gauge = status.p_runtime_servers_max_repl_lag_map[key];
+		status.p_dyn_gauge_array[p_hg_dyn_gauge::runtime_servers_max_replication_lag]->Remove(gauge);
+		status.p_runtime_servers_max_repl_lag_map.erase(key);
+
+		gauge = status.p_runtime_servers_use_ssl_map[key];
+		status.p_dyn_gauge_array[p_hg_dyn_gauge::runtime_servers_use_ssl]->Remove(gauge);
+		status.p_runtime_servers_use_ssl_map.erase(key);
+
+		gauge = status.p_runtime_servers_max_lat_map[key];
+		status.p_dyn_gauge_array[p_hg_dyn_gauge::runtime_servers_max_latency_ms]->Remove(gauge);
+		status.p_runtime_servers_max_lat_map.erase(key);
+		////////////////////////////////////////////////////////////////////
 	}
 
 	wrunlock();

--- a/lib/MySQL_HostGroups_Manager.cpp
+++ b/lib/MySQL_HostGroups_Manager.cpp
@@ -572,7 +572,52 @@ hg_metrics_map = std::make_tuple(
 			"proxysql_connpool_conns_status",
 			"The status of the backend server (1 - ONLINE, 2 - SHUNNED, 3 - OFFLINE_SOFT, 4 - OFFLINE_HARD, 5 - SHUNNED_REPLICATION_LAG).",
 			metric_tags {}
+		),
+		// PMM-Compatibility metrics
+		////////////////////////////////////////////////////////////////////////
+		std::make_tuple (
+			p_hg_dyn_gauge::runtime_servers_status,
+			"proxysql_runtime_mysql_servers_status",
+			"The status of the backend server (1 - ONLINE, 2 - SHUNNED, 3 - OFFLINE_SOFT, 4 - OFFLINE_HARD, 5 - SHUNNED_REPLICATION_LAG).",
+			metric_tags {}
+		),
+		std::make_tuple (
+			p_hg_dyn_gauge::runtime_servers_weight,
+			"proxysql_runtime_mysql_servers_weight",
+			"Configured 'weight' for the backend server.",
+			metric_tags {}
+		),
+		std::make_tuple (
+			p_hg_dyn_gauge::runtime_servers_compression,
+			"proxysql_runtime_mysql_servers_compression",
+			"If 'compression' is enabled for the backend server.",
+			metric_tags {}
+		),
+		std::make_tuple (
+			p_hg_dyn_gauge::runtime_servers_max_connections,
+			"proxysql_runtime_mysql_servers_max_connections",
+			"Configured 'max_connections' for the backend server.",
+			metric_tags {}
+		),
+		std::make_tuple (
+			p_hg_dyn_gauge::runtime_servers_max_replication_lag,
+			"proxysql_runtime_mysql_servers_max_replication_lag",
+			"Configured 'max_replication_lag' for the backend server.",
+			metric_tags {}
+		),
+		std::make_tuple (
+			p_hg_dyn_gauge::runtime_servers_use_ssl,
+			"proxysql_runtime_mysql_servers_use_ssl",
+			"If 'ssl' is enabled for the backend server.",
+			metric_tags {}
+		),
+		std::make_tuple (
+			p_hg_dyn_gauge::runtime_servers_max_latency_ms,
+			"proxysql_runtime_mysql_servers_max_latency_ms",
+			"Configured 'max_latency_ms' for the backend server.",
+			metric_tags {}
 		)
+		////////////////////////////////////////////////////////////////////////
 	}
 );
 
@@ -3408,6 +3453,69 @@ void MySQL_HostGroups_Manager::p_update_connection_pool() {
 			// proxysql_connection_pool_status metric
 			p_update_connection_pool_update_gauge(endpoint_id, common_labels,
 				status.p_connection_pool_status_map, ((int)mysrvc->get_status()) + 1, p_hg_dyn_gauge::connection_pool_status);
+
+			// PMM-Compatibility metrics
+			////////////////////////////////////////////////////////////////////
+			std::map<std::string, std::string> srvs_common_labels = common_labels;
+			srvs_common_labels.insert({"gtid_port", std::to_string(mysrvc->gtid_port)});
+
+			p_update_connection_pool_update_gauge(
+				endpoint_id,
+				srvs_common_labels,
+				status.p_runtime_servers_status_map,
+				((int)mysrvc->get_status()) + 1,
+				p_hg_dyn_gauge::runtime_servers_status
+			);
+
+			p_update_connection_pool_update_gauge(
+				endpoint_id,
+				srvs_common_labels,
+				status.p_runtime_servers_weigth_map,
+				mysrvc->weight,
+				p_hg_dyn_gauge::runtime_servers_weight
+			);
+
+			p_update_connection_pool_update_gauge(
+				endpoint_id,
+				srvs_common_labels,
+				status.p_runtime_servers_compress_map,
+				mysrvc->compression,
+				p_hg_dyn_gauge::runtime_servers_compression
+			);
+
+			p_update_connection_pool_update_gauge(
+				endpoint_id,
+				srvs_common_labels,
+				status.p_runtime_servers_max_conns_map,
+				mysrvc->max_connections,
+				p_hg_dyn_gauge::runtime_servers_max_connections
+			);
+
+			p_update_connection_pool_update_gauge(
+				endpoint_id,
+				srvs_common_labels,
+				status.p_runtime_servers_max_repl_lag_map,
+				mysrvc->max_replication_lag,
+				p_hg_dyn_gauge::runtime_servers_max_replication_lag
+			);
+
+			p_update_connection_pool_update_gauge(
+				endpoint_id,
+				srvs_common_labels,
+				status.p_runtime_servers_use_ssl_map,
+				mysrvc->use_ssl,
+				p_hg_dyn_gauge::runtime_servers_use_ssl
+			);
+
+			p_update_connection_pool_update_gauge(
+				endpoint_id,
+				srvs_common_labels,
+				status.p_runtime_servers_max_lat_map,
+				mysrvc->max_latency_us / 1000,
+				p_hg_dyn_gauge::runtime_servers_max_latency_ms
+			);
+
+			////////////////////////////////////////////////////////////////////
 		}
 	}
 

--- a/lib/MySQL_Logger.cpp
+++ b/lib/MySQL_Logger.cpp
@@ -1460,7 +1460,9 @@ int MySQL_Logger::processEvents(SQLite3DB * statsdb , SQLite3DB * statsdb_disk) 
 			int rows_to_keep = maxInMemorySize - events.size();
 			if (current_rows > rows_to_keep) {
 				int rows_to_delete = (current_rows - rows_to_keep);
-				string delete_stmt = "DELETE FROM stats_mysql_query_events ORDER BY id LIMIT " + to_string(rows_to_delete);
+				string query = "SELECT MAX(id) FROM (SELECT id FROM stats_mysql_query_events ORDER BY id LIMIT " + to_string(rows_to_delete) + ")";
+				int maxIdToDelete = statsdb->return_one_int(query.c_str());
+				string delete_stmt = "DELETE FROM stats_mysql_query_events WHERE id <= " + to_string(maxIdToDelete);
 				statsdb->execute(delete_stmt.c_str());
 			}
 		}

--- a/lib/MySQL_Variables.cpp
+++ b/lib/MySQL_Variables.cpp
@@ -52,6 +52,8 @@ MySQL_Variables::MySQL_Variables() {
 	ignore_vars.push_back("read_rnd_buffer_size");
 	// NOTE: This variable has been temporarily ignored. Check issues #3442 and #3441.
 	ignore_vars.push_back("session_track_schema");
+	// NOTE: This variable has been temporarily ignored. Check issues #4839
+	ignore_vars.push_back("session_track_system_variables");
 	variables_regexp = "";
 	for (auto i = 0; i < SQL_NAME_LAST_HIGH_WM; i++) {
 		// we initialized all the internal_variable_name if set to NULL

--- a/lib/ProxySQL_Admin.cpp
+++ b/lib/ProxySQL_Admin.cpp
@@ -9937,7 +9937,7 @@ void ProxySQL_Admin::stats___mysql_global() {
 		free(query);
 	}
 	if (GloMyLogger != nullptr) {
-		const string prefix = "MySQL_Logger-";
+		const string prefix = "MySQL_Logger_";
 		std::unordered_map<std::string, unsigned long long> metrics = GloMyLogger->getAllMetrics();
 		for (std::unordered_map<std::string, unsigned long long>::iterator it = metrics.begin(); it != metrics.end(); it++) {
 			unsigned int l = strlen(a) + prefix.length() + it->first.length() + 32;

--- a/lib/mysql_connection.cpp
+++ b/lib/mysql_connection.cpp
@@ -774,11 +774,11 @@ void MySQL_Connection::connect_start_SetCharset() {
 		csname = mysql_variables.client_get_value(myds->sess, SQL_CHARACTER_SET);
 	}
 
-	const MARIADB_CHARSET_INFO * c = NULL;
+	MARIADB_CHARSET_INFO * c = NULL;
 	if (csname)
-		c = proxysql_find_charset_nr(atoi(csname));
+		c = (MARIADB_CHARSET_INFO *)proxysql_find_charset_nr(atoi(csname));
 	else
-		c = proxysql_find_charset_name(mysql_thread___default_variables[SQL_CHARACTER_SET]);
+		c = (MARIADB_CHARSET_INFO *)proxysql_find_charset_name(mysql_thread___default_variables[SQL_CHARACTER_SET]);
 
 	if (!c) {
 		// LCOV_EXCL_START
@@ -786,6 +786,21 @@ void MySQL_Connection::connect_start_SetCharset() {
 		assert(0);
 		// LCOV_EXCL_STOP
 	}
+
+	if (c->nr > 255) {
+		const char *csname_default = c->csname;
+		c = NULL;
+		c = (MARIADB_CHARSET_INFO *)proxysql_find_charset_name(csname_default);
+		if (!c) {
+			// LCOV_EXCL_START
+			proxy_error("Not existing charset number %s\n", mysql_thread___default_variables[SQL_CHARACTER_SET]);
+			assert(0);
+			// LCOV_EXCL_STOP
+		}
+	}
+
+
+
 	{
 		/* We are connecting to backend setting charset in mysql_options.
 		 * Client already has sent us a character set and client connection variables have been already set.

--- a/lib/set_parser.cpp
+++ b/lib/set_parser.cpp
@@ -162,7 +162,7 @@ void SetParser::generateRE_parse1v2() {
 		// - variable name , with double @ (session variable) or single @ (user defiend variable)
 		// - strings that includes words, spaces and commas
 		// - single quote string
-		string  sw0  = "(?:\\w+|\"[\\w, ]+\"|\'[\\w, ]+\'|@(?:|@)\\w+|\'\')";
+		string  sw0  = "(?:\\w+|\"[\\w, ]+\"|\'[\\w, ]+\'|@(?:|@|@session\\.|@global\\.)\\w+|\'\')";
 		string  mw0  = "(?:" + sw0 + "(?: *, *" + sw0 + ")*)"; // multiple words, separated by comma and random spaces
 		string  fww  = "(?:(?:REPLACE|IFNULL|CONCAT)\\( *" + mw0 + "\\))"; // functions REPLACE|IFNULL|CONCAT having argument multiple words
 		string rfww2 = "(?:(?:REPLACE|IFNULL|CONCAT)\\( *" + fww   + " *, *" + mw0 + "\\))"; //functions REPLACE|IFNULL|CONCAT calling the same functions

--- a/test/tap/tap/utils.cpp
+++ b/test/tap/tap/utils.cpp
@@ -243,13 +243,15 @@ int mysql_query_t__(MYSQL* mysql, const char* query, const char* f, int ln, cons
 	return mysql_query(mysql, query);
 }
 
-int show_variable(MYSQL *mysql, const string& var_name, string& var_value) {
-	char query[128];
+int show_variable(MYSQL *mysql, const string& var_name, string& var_value, bool new_connection) {
 
-	snprintf(query, sizeof(query),"show variables like '%s'", var_name.c_str());
-	if (mysql_query(mysql, query)) {
+	std::string query = "show variables ";
+	query += (new_connection == true ? "/* create_new_connection=1 */ " : "");
+	query += " like '" + var_name + "'";
+
+	if (mysql_query(mysql, query.c_str())) {
 		fprintf(stderr, "Failed to execute query [%s] : no %d, %s\n",
-				query, mysql_errno(mysql), mysql_error(mysql));
+				query.c_str(), mysql_errno(mysql), mysql_error(mysql));
 		return exit_status();
 	}
 

--- a/test/tap/tap/utils.h
+++ b/test/tap/tap/utils.h
@@ -119,7 +119,7 @@ int mysql_query_t__(MYSQL* mysql, const char* query, const char* f, int ln, cons
 		} \
 	} while(0)
 
-int show_variable(MYSQL *mysql, const std::string& var_name, std::string& var_value);
+int show_variable(MYSQL *mysql, const std::string& var_name, std::string& var_value, bool new_connection=false);
 int show_admin_global_variable(MYSQL *mysql, const std::string& var_name, std::string& var_value);
 int set_admin_global_variable(MYSQL *mysql, const std::string& var_name, const std::string& var_value);
 int get_server_version(MYSQL *mysql, std::string& version);

--- a/test/tap/tests/test_prometheus_metrics-t.cpp
+++ b/test/tap/tests/test_prometheus_metrics-t.cpp
@@ -29,6 +29,7 @@ using std::vector;
 using std::pair;
 using std::string;
 using std::tuple;
+using std::map;
 
 CommandLine cl;
 
@@ -891,7 +892,157 @@ const vector<pair<string, tuple<setup, metric_trigger, metric_check>>> metric_te
 	},
 };
 
-using std::map;
+string status_to_string(int status) {
+	if (status == 1) {
+		return "ONLINE";
+	} else if (status == 2) {
+		return "SHUNNED";
+	} else if (status == 3) {
+		return "OFFLINE_SOFT";
+	} else if (status == 4) {
+		return "OFFLINE_HARD";
+	} else if (status == 5) {
+		return "SHUNNED_REPLICATION_LAG";
+	} else {
+		assert(0);
+	}
+}
+
+const char RUNTIME_SRVS[] {
+	"SELECT"
+		" hostgroup_id,"
+		" (hostname || \":\" || port) AS endpoint,"
+		" gtid_port,"
+		" status,"
+		" weight,"
+		" compression,"
+		" max_connections,"
+		" max_replication_lag,"
+		" use_ssl,"
+		" max_latency_ms"
+	" FROM"
+		" runtime_mysql_servers"
+};
+
+enum SRV_FLD {
+	hosgroup_id = 0,
+	endpoint,
+	gtid_port,
+	status,
+	weight,
+	compression,
+	max_connections,
+	max_replication_lag,
+	use_ssl,
+	max_latency_ms
+};
+
+const map<string,int> m_srvs_metrics {
+	{ "proxysql_runtime_mysql_servers_status", SRV_FLD::status },
+	{ "proxysql_runtime_mysql_servers_weight", SRV_FLD::weight },
+	{ "proxysql_runtime_mysql_servers_compression", SRV_FLD::compression },
+	{ "proxysql_runtime_mysql_servers_max_connections", SRV_FLD::max_connections },
+	{ "proxysql_runtime_mysql_servers_max_replication_lag", SRV_FLD::max_replication_lag },
+	{ "proxysql_runtime_mysql_servers_use_ssl", SRV_FLD::use_ssl },
+	{ "proxysql_runtime_mysql_servers_max_latency_ms", SRV_FLD::max_latency_ms },
+};
+
+using p_srv_metrics = pair<mysql_row_t,vector<pair<string,double>>>;
+using nlohmann::json;
+
+int check_srvs_metrics(
+	const vector<mysql_row_t>& srvs, const map<string,double>& cur_metrics
+) {
+	const auto match_start = [] (const string s1, const string s2) {
+		return s1.rfind(s2) == 0;
+	};
+
+	// 1. Find all defined metrics
+	bool match = true;
+	const uint32_t exp_checks = m_srvs_metrics.size() * srvs.size();
+	uint32_t act_checks = 0;
+
+	// 2. Check all defined metrics match
+	for (const mysql_row_t& row : srvs) {
+		diag(
+			"Checking matching ept metrics for server   srv_row=\"%s\"",
+			json(row).dump().c_str()
+		);
+
+		for (const auto& p_id_val : cur_metrics) {
+			auto metric_it {
+				std::find_if(m_srvs_metrics.begin(), m_srvs_metrics.end(),
+					[p_id_val] (const auto& p) { return p_id_val.first.rfind(p.first, 0) == 0; }
+				)
+			};
+
+			if (metric_it != std::end(m_srvs_metrics)) {
+				const string& srv_ept { row[SRV_FLD::endpoint] };
+				const string& srv_hg { row[SRV_FLD::hosgroup_id] };
+				const auto& tags { extract_metric_tags(p_id_val.first) };
+
+				if (tags.at("endpoint") == srv_ept && tags.at("hostgroup") == srv_hg) {
+					diag(
+						"Checking matching ept metric   ept=\"%s\" hg=%s metric=\"%s\" val=%lf",
+						srv_ept.c_str(), srv_hg.c_str(), p_id_val.first.c_str(), p_id_val.second
+					);
+
+					const string mval_str {
+						metric_it->first.rfind("status") != std::string::npos ?
+						status_to_string(int32_t(p_id_val.second))
+						: std::to_string(int32_t(p_id_val.second))
+					};
+
+					match = row[metric_it->second] == mval_str;
+					match = row[SRV_FLD::gtid_port] == tags.at("gtid_port");
+					act_checks += 1;
+
+					if (!match) {
+						diag(
+							"FAIL - Mismatch found checking metric   "
+								"exp_val=%s act_val=%s exp_gtid_port=%s act_gtid_port=%s",
+							row[metric_it->second].c_str(),
+							mval_str.c_str(),
+							row[SRV_FLD::gtid_port].c_str(),
+							tags.at("gtid_port").c_str()
+						);
+					}
+				}
+			}
+		}
+	}
+
+	ok(match, "Metrics values should match for Admin and Exporter");
+	ok(
+		exp_checks == act_checks,
+		"All supported metrics should be found for server entries   exp_checks=%d act_checks=%d",
+		exp_checks, act_checks
+	);
+
+	return EXIT_SUCCESS;
+}
+
+int coherence_check_runtime_servers(MYSQL* admin) {
+	map<string,double> cur_metrics {};
+	int rc = get_cur_metrics(admin, cur_metrics);
+	if (rc) { return EXIT_FAILURE; }
+
+	auto srvs_rows { mysql_query_ext_rows(admin, RUNTIME_SRVS) };
+	if (srvs_rows.first) {
+		diag(
+			"Failed to fetch 'runtime_mysql_servers' rows   errno=%d error=\"%s\" query=\"%s\"",
+			srvs_rows.first, mysql_error(admin), RUNTIME_SRVS
+		);
+		return EXIT_FAILURE;
+	}
+
+	return check_srvs_metrics(srvs_rows.second, cur_metrics);
+}
+
+const vector<pair<string, std::function<int(MYSQL*)>>> coherence_checks {
+	// Check current 'runtime_mysql_servers' values matches the ones exposed by its metrics
+	{ "proxysql_runtime_mysql_servers_{*} - Matching Admin Interface", coherence_check_runtime_servers },
+};
 
 
 int main(int argc, char** argv) {
@@ -901,7 +1052,10 @@ int main(int argc, char** argv) {
 		return EXIT_FAILURE;
 	}
 
-	plan(metric_tests.size() * 4);
+	plan(
+		metric_tests.size() * 4
+		+ coherence_checks.size() * 2
+	);
 
 	for (const auto& metric_test : metric_tests) {
 		// Initialize Admin connection
@@ -957,6 +1111,25 @@ int main(int argc, char** argv) {
 		// Close the connections used for this test
 		mysql_close(proxysql);
 		mysql_close(proxysql_admin);
+	}
+
+	{
+		MYSQL* admin = mysql_init(NULL);
+
+		if (!mysql_real_connect(admin, cl.host, cl.admin_username, cl.admin_password, NULL, cl.admin_port, NULL, 0)) {
+			fprintf(stderr, "File %s, line %d, Error: %s\n", __FILE__, __LINE__, mysql_error(admin));
+			return EXIT_FAILURE;
+		}
+
+		for (const auto& p_id_check : coherence_checks) {
+			const string& id { p_id_check.first.c_str() };
+
+			diag("Started metrics coherence check   id=\"%s\"", id.c_str());
+			int rc = p_id_check.second(admin);
+			diag("Finished metric coherence check   id=\"%s\" rc=%d", id.c_str(), rc);
+		}
+
+		mysql_close(admin);
 	}
 
 	return exit_status();

--- a/test/tap/tests/test_utf8mb4_as_ci-4841-t.cpp
+++ b/test/tap/tests/test_utf8mb4_as_ci-4841-t.cpp
@@ -1,0 +1,57 @@
+/**
+ * @file test_utf8mb4_as_ci-4841-t.cpp
+ * @brief This test checks the use of collation 305 (utf8mb4_as_ci) .
+ * @details The test performs a 'SET NAMES' query to set utf8mb4_as_ci collation, then run a query
+ * on backend to verify the collation.
+ */
+
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
+#include <unistd.h>
+
+#include <string>
+#include "mysql.h"
+
+#include "tap.h"
+#include "command_line.h"
+#include "utils.h"
+
+int main(int argc, char** argv) {
+	CommandLine cl;
+
+	if(cl.getEnv())
+		return exit_status();
+
+	plan(1);
+	diag("Testing SET NAMES utf8mb4 COLLATE utf8mb4_0900_as_ci");
+
+	MYSQL* mysql = mysql_init(NULL);
+	if (!mysql)
+		return exit_status();
+
+	if (!mysql_real_connect(mysql, cl.host, cl.username, cl.password, NULL, cl.port, NULL, 0)) {
+		fprintf(stderr, "Failed to connect to database: Error: %s\n",
+				mysql_error(mysql));
+		return exit_status();
+	}
+
+	char * query = (char *)"SET NAMES utf8mb4 COLLATE utf8mb4_0900_as_ci";
+	if (mysql_query(mysql, query)) {
+		fprintf(stderr, "%s: Error: %s\n",
+				query,
+				mysql_error(mysql));
+		return exit_status();
+	}
+
+	std::string var_collation_connection = "collation_connection";
+	std::string var_value;
+
+	show_variable(mysql, var_collation_connection, var_value, true);
+	ok(var_value.compare("utf8mb4_0900_as_ci") == 0, "collation_connection , Expected utf8mb4_0900_as_ci . Actual %s", var_value.c_str()); // ok_1
+
+	mysql_close(mysql);
+
+	return exit_status();
+}
+


### PR DESCRIPTION
- **Adding a circular buffer to MySQL_Logger**
- **Renamed mysql-eventslog_memory_history_size to mysql-eventslog_buffer_history_size**
- **bump version to 2.7.2 at the beginning of the development cycle**
- **update triggers**
- **pass github context to scripts**
- **show correct run-name set correct concurrency group execute on dependency success**
- **add CI-trigger**
- **opdate actions to use CI-trigger**
- **pass specific matrix for mysq/mariadb/pgsql**
- **use correct matrix vars**
- **Reimplementation of the circular buffer for Query Logging**
- **Implemented table stats_mysql_query_events**
- **Reimplementation of MySQL_Logger_CircularBuffer::get_all_events()**
- **First implementation of insertMysqlEventsIntoDb()**
- **Add history_mysql_query_events in statsdb_disk**
- **Implementation of processEvents() and DUMP EVENTSLOG commands**
- **Added stats_mysql_eventslog_sync_buffer_to_disk**
- **Adding documentation on in memory eventslog**
- **Improved documentation**
- **Added variable eventslog_buffer_max_query_length**
- **add CI-3p-postgresql**
- **MySQL_Event log buffering enhancements**
- **MySQL_Logger::getAllMetrics()**
- **Fixed crash caused by sending single semicolon (;) on admin interface**
- **Added TAP test**
- **Updated default value of cache_empty_result to -1, indicating that it has not been explicitly set**
- **Added TAP test**
- **Drafting handling of errors in MySQL Events log**
- **Updated query**
- *** Introduced a 5% jitter to cache_ttl to increase the likelihood of   distributing DNS resolution across multiple intervals, reducing the   chance of simultaneous expiry times. * Added a small delay after queuing DNS records, allowing DNS resolver   thread time to process as many hostnames as possible before assessing   the need for additional helper threads. This helps prevent 'DNS   resolver queue too big' warnings in the logs.**
- **Drafting handling of errors in MySQL Events log 2**
- **Added overflow_safe_multiply()**
- **Implemented overflow-safe multiplication for mysql_thread___threshold_resultset_size**
- **Added TAP test**
- **Adding some errors in MySQL Events log**
- **Optimization**
- **Updated TAP test**
- **Fixed admin_host**
- **Fixed admin_host**
- **Fixed admin port**
- **Adding more errors in MySQL Events log**
- **Crash fix: Add integrity check for 'column-count' packet to 'libmariadbclient'**
- **Add regression test for 'column-count' integrity check in 'libmariadbclient'**
- **Previously mysql_hostgroup_attributes was not read from configuration file. Now mysql_hostgroup_attributes will be read from configuration file. backporting of #4704**
- **Adding errno into in-memory query logging**
- **Fix worker threads stalling race condition on RESUME command**
- **Prevent busy-waiting in active wait during 'listener_del'**
- **Fix potential invalid syntax in TAP test queries**
- **remove postgres GH action**
- **make postgres GH action conditional**
- **Update CI-3p-sqlalchemy.yml**
- **add workflow_dispatch inputs add run-mariadb where missing make run-pgsql conditional**
- **rephrase run-pgsql condition**
- **Default compression level was 6 for MySQL clients and this was making ProxySQL slower.**
- **Remove print of jemalloc conf prior to cmd options handling**
- **Fix memory leak on 'ssl_params' fetch in Monitor**
- **CentOS7 Ubuntu16 build fix**
- **Fix leak of SSL caches for auxiliary threads**
- **add missing fedora41 for arm64 add make pkglist helper**
- **Export MySQL_Logger metrics**
- **Remove test_empty_schemaname-t.cpp**
- **Fix tap test related to change in CI config**
- **Removed test of character_set_database**
- **verbose output in mysql_query_logging_memory-t**
- **1.  Moved setting of compression level to correct place. 2. Corrected compression tap test.**
- **made diff as singed.**
- **Fix typo in 'circularBufferEventsAddedCount' metric name**
- **Add Prometheus metrics support for 'MySQL_Logger' module**
- **Fix typo for 'MySQL_Logger' metric 'totalGetAllEventsTimeMicros'**
- **Add Prometheus metric for 'MySQL_Logger' metric 'totalGetAllEventsTimeMicros'**
- **Fix 'plan' test count for 'set_character_set-t'**
- **New connection in mysql_query_logging_memory-t**
- **Fix compilation for Centos 7 removing 'auto' reference**
- **Delete on stats_mysql_query_events without LIMIT**
- **Replace dash with underscore in MySQL_Logger status variables**
- **bump version to 2.7.3 at the beginning of the development cycle**
- **Fix issue #4841**
- **Ignore tracking of session_track_system_variables**
- **Add PMM compatible 'runtime_mysql_servers_*' metrics to Prometheus exporter**
- **Update 'test_prometheus_metrics-t' with new coherence tests**
- **Make 'runtime_servers_*' consistent with dynamic 'gauge' metrics**
- **try to get make working**
